### PR TITLE
save AntennaAccount key  when create AntennaAccount without key params

### DIFF
--- a/src/wallet-core/antenna-account.ts
+++ b/src/wallet-core/antenna-account.ts
@@ -41,9 +41,10 @@ export class AntennaAccount implements IAccount {
       this.privateKey = privateKey;
       this.antenna.iotx.accounts.privateKeyToAccount(privateKey);
     } else {
-      this.antenna.iotx.accounts.create(
+      const acc = this.antenna.iotx.accounts.create(
         crypto.randomBytes(128).toString("hex")
       );
+      this.privateKey = acc.privateKey;
     }
   }
 


### PR DESCRIPTION
- Description: AntennaAccount key  when create AntennaAccount without key params
- Fixes #40 
